### PR TITLE
Fix module path in `go.mod`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module glazetray
+module github.com/Drysua/glazetray
 
 go 1.23.4
 


### PR DESCRIPTION
This PR fixes the module path in the `go.mod` file to correctly reflect the repository's location on GitHub. Currently, the module path is declared as `module glazetray`, which causes issues when users try to install the package using `go install` or other Go tooling. The correct module path should be `module github.com/Drysua/glazetray`.

Currently, I faced issue when trying to install this using the cmd `go install github.com/Drysua/glazetray@latest`
Output
```
PS C:\Users\C> go install github.com/Drysua/glazetray@latest
go: github.com/Drysua/glazetray@latest: version constraints conflict:
        github.com/Drysua/glazetray@v0.0.0-20250107083142-faeb1e84718d: parsing go.mod:
        module declares its path as: glazetray
                but was required as: github.com/Drysua/glazetray
```